### PR TITLE
[DD-2607]: Save Multi-LiCa calibration data in our format

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -83,3 +83,5 @@
       sensors_config_path: /etc/tractor_config/sensors_config.yaml
       translation_rmse_threshold_m: 0.1
       rotation_error_threshold_degree: 2.5
+      updated_calibration_file_path: /data/bags/calibration_data/
+

--- a/launch/calibration.launch.py
+++ b/launch/calibration.launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
                 'lidar_topics': left_to_center_lidar_calibration_node_topics
             }
         ],
-        remappings=[('/lidar_calibration', '/start_left_lidar_calibration')],
+        remappings=[('/lidar_calibration', '/offline_calibration/start_left_lidar_calibration')],
         output="screen",
     )
 
@@ -58,7 +58,7 @@ def generate_launch_description():
                 'lidar_topics': right_to_center_lidar_calibration_node_topics
             }
         ],
-        remappings=[('/lidar_calibration', '/start_right_lidar_calibration')],
+        remappings=[('/lidar_calibration', '/offline_calibration/start_right_lidar_calibration')],
         output="screen",
     )
 


### PR DESCRIPTION
This PR brings the following changes:
- Creates separate files with calibration data in the format of our current `sensors_config.yaml`.
- Both files are tagged with the Lidar names.