### PR TITLE
[DD-2652]: Changes to setup.py to add submodules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,14 @@
 import os
 from glob import glob
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 package_name = "multi_lidar_calibrator"
-submodules = "multi_lidar_calibrator/calibration"
 
 setup(
     name=package_name,
     version="0.0.1",
-    packages=[package_name, submodules],
+    packages= find_packages(exclude=["test", "doc"]),
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         ("share/" + package_name, ["package.xml"]),


### PR DESCRIPTION
This PR brings the following changes:
- use `find_packages()` from setuptools to add the submodules.