### PR TITLE
[DD-2656] : Code change to handle different version of scipy, preventing crashes

### DIFF
--- a/TEASER-plusplus/examples/teaser_python_fpfh_icp/helpers.py
+++ b/TEASER-plusplus/examples/teaser_python_fpfh_icp/helpers.py
@@ -1,6 +1,7 @@
 import open3d as o3d
 import numpy as np 
 from scipy.spatial import cKDTree
+import scipy
 import teaserpp_python
 
 def pcd2xyz(pcd):
@@ -18,7 +19,12 @@ def extract_fpfh(pcd, voxel_size):
 
 def find_knn_cpu(feat0, feat1, knn=1, return_distance=False):
   feat1tree = cKDTree(feat1)
-  dists, nn_inds = feat1tree.query(feat0, k=knn, n_jobs=-1)
+  
+  if version.parse(scipy.__version__) >= version.parse('1.6.0'):
+      dists, nn_inds = feat1tree.query(feat0, k=knn, workers=-1)
+  else:
+      dists, nn_inds = feat1tree.query(feat0, k=knn, n_jobs=-1)
+
   if return_distance:
     return nn_inds, dists
   else:

--- a/multi_lidar_calibrator/calibration/Calibration.py
+++ b/multi_lidar_calibrator/calibration/Calibration.py
@@ -9,6 +9,8 @@ from scipy.spatial import cKDTree
 from .Geometry import Rotation, TransformationMatrix, Translation
 from .Lidar import Lidar
 from scipy.spatial.transform import Rotation as R
+import scipy
+from packaging import version
 
 def visualize_calibration(lidar_list: list, transformed=True, only_paint=False):
     """
@@ -246,7 +248,11 @@ class Calibration:
     
     def find_knn_cpu(self, feat0, feat1, knn=1, return_distance=False):
         feat1tree = cKDTree(feat1)
-        dists, nn_inds = feat1tree.query(feat0, k=knn, n_jobs=-1)
+        # Use scipy version to determine the args for the query function
+        if version.parse(scipy.__version__) >= version.parse('1.6.0'):
+            dists, nn_inds = feat1tree.query(feat0, k=knn, workers=-1)
+        else:
+            dists, nn_inds = feat1tree.query(feat0, k=knn, n_jobs=-1)
         if return_distance:
             return nn_inds, dists
         else:


### PR DESCRIPTION
This PR brings the following changes:
- Code change to handle any version of `scipy` to prevent crashes.
- `n_jobs` has been changed to `workers` for newer versions of scipy.