### PR TITLE
[DD-2717]: Fixed /etc/tractor_config/ file

### DIFF
--- a/config/params.yaml
+++ b/config/params.yaml
@@ -80,7 +80,7 @@
     r_runs: 10
 
     calibration:
-      sensors_config_path: /etc/tractor_config/sensors_config.yaml
+      sensors_config_path: /home/docker_user/tractor_config/sensors_config.yaml
       translation_rmse_threshold_m: 0.1
       rotation_error_threshold_degree: 2.5
       updated_calibration_file_path: /data/bags/calibration_data/


### PR DESCRIPTION
This PR fixes the path to `/etc/tractor_config` to `/home/docker_user/tractor_config`