### PR TITLE
[SW-2272]: Add fixes for Multi-LiCa calibration

### DIFF
--- a/TEASER-plusplus/teaser/src/graph.cc
+++ b/TEASER-plusplus/teaser/src/graph.cc
@@ -9,7 +9,7 @@
 #include "teaser/graph.h"
 #include "pmc/pmc.h"
 
-vector<int> teaser::MaxCliqueSolver::findMaxClique(teaser::Graph graph) {
+std::vector<int> teaser::MaxCliqueSolver::findMaxClique(teaser::Graph graph) {
 
   // Handle deprecated field
   if (!params_.solve_exactly) {
@@ -17,8 +17,8 @@ vector<int> teaser::MaxCliqueSolver::findMaxClique(teaser::Graph graph) {
   }
 
   // Create a PMC graph from the TEASER graph
-  vector<int> edges;
-  vector<long long> vertices;
+  std::vector<int> edges;
+  std::vector<long long> vertices;
   vertices.push_back(edges.size());
 
   const auto all_vertices = graph.getVertices();
@@ -52,7 +52,7 @@ vector<int> teaser::MaxCliqueSolver::findMaxClique(teaser::Graph graph) {
   in.vertex_search_order = "deg";
 
   // vector to represent max clique
-  vector<int> C;
+  std::vector<int> C;
 
   // upper-bound of max clique
   G.compute_cores();

--- a/multi_lidar_calibrator/multi_lidar_calibrator.py
+++ b/multi_lidar_calibrator/multi_lidar_calibrator.py
@@ -314,10 +314,32 @@ class MultiLidarCalibrator(Node):
         for key in self.lidar_data.keys():
             # convert data from ros to pcd needed for open3d
             t = rnp.numpify(self.lidar_data[key][0])
-            pcd = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(t["xyz"]))
+            
+            # Extract x, y, z coordinates - common field names in PointCloud2
+            if 'x' in t.dtype.names and 'y' in t.dtype.names and 'z' in t.dtype.names:
+                # Stack x, y, z fields into a single array
+                xyz = np.column_stack((t['x'], t['y'], t['z']))
+            elif 'xyz' in t.dtype.names:
+                xyz = t['xyz']
+            else:
+                self.get_logger().error(f"Cannot find x, y, z or xyz fields in PointCloud2 data. Available fields: {t.dtype.names}")
+                continue
+                
+            pcd = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(xyz))
+            
             for i in range(1, self.frame_count):
                 t = rnp.numpify(self.lidar_data[key][i])
-                pcd += o3d.geometry.PointCloud(o3d.utility.Vector3dVector(t["xyz"]))
+                
+                # Extract x, y, z coordinates for additional frames
+                if 'x' in t.dtype.names and 'y' in t.dtype.names and 'z' in t.dtype.names:
+                    xyz = np.column_stack((t['x'], t['y'], t['z']))
+                elif 'xyz' in t.dtype.names:
+                    xyz = t['xyz']
+                else:
+                    self.get_logger().error(f"Cannot find x, y, z or xyz fields in frame {i}. Available fields: {t.dtype.names}")
+                    continue
+                    
+                pcd += o3d.geometry.PointCloud(o3d.utility.Vector3dVector(xyz))
             self.lidar_dict[key].load_pcd(pcd)
         self.get_logger().info("Converted all the needed ros-data")
 


### PR DESCRIPTION
The PR fixes 2 problem which causes multi_lidar_calibration to crash

1) teaserpp_python was not getting installed due to std::vector errors.
2) pointcloud does not have field xyz but we have seperate field x y and z.